### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
-
+  
 permissions:
-    contents: read
+    contents: write
     pull-requests: write
     pages: write
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: CI
 
+permissions:
+    contents: read
+    pull-requests: write
+    pages: write
+
 on:
     push:
         branches:


### PR DESCRIPTION
Potential fix for [https://github.com/baiyuchen1228/baiyuchen1228.github.io/security/code-scanning/15](https://github.com/baiyuchen1228/baiyuchen1228.github.io/security/code-scanning/15)

To fix the issue, add a `permissions` block at the root level of the workflow. This will ensure that all jobs inherit the least-privilege permissions unless overridden explicitly. In this case, the workflow requires permissions for reading repository contents, creating pull requests, and pushing code. These can be scoped as follows:

- `contents: read` for all jobs to read repository contents.
- `pull-requests: write` for creating pull requests.
- `pages: write` for deploying to GitHub Pages.

This configuration ensures that the `GITHUB_TOKEN` permissions are explicitly defined and limited to only what's needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
